### PR TITLE
Update googleAuthWrapper.js

### DIFF
--- a/lib/googleAuthWrapper.js
+++ b/lib/googleAuthWrapper.js
@@ -35,6 +35,7 @@ function authorize(storagePath,
                    clientSecrets,
                    scopes,
                    authCallback) {
+  clientSecrets=clientSecrets.replace(/\.json$/g, ''); //Remove any trailing .json because we will append it later
   const oauthClient = createOauthClient(storagePath, clientSecrets);
   const url = oauthClient.generateAuthUrl({ access_type: 'offline', 
                                           scope: scopes });


### PR DESCRIPTION
If clientSecrets filename had the .json extension, it was invalidating the final path because it's appended later. To avoid this, if ".json" is found at the end of clientSecrets, it's dropped early then appended as before. This way it doesn't matter if ".json" is provided initially.